### PR TITLE
Bugfix for search orders with empty string or null

### DIFF
--- a/app/Http/Controllers/Admin/Orders/OrderController.php
+++ b/app/Http/Controllers/Admin/Orders/OrderController.php
@@ -56,7 +56,7 @@ class OrderController extends Controller
         $list = $this->orderRepo->listOrders('created_at', 'desc');
 
         if (request()->has('q')) {
-            $list = $this->orderRepo->searchOrder(request()->input('q'));
+            $list = $this->orderRepo->searchOrder(request()->input('q') ?? '');
         }
 
         $orders = $this->orderRepo->paginateArrayResults($this->transFormOrder($list), 10);


### PR DESCRIPTION
### Bugfix for search orders

If no string is providing in query string param, then send empty string to `OrderRepository@searchOrder`
