### PR TITLE
Fixes #228

### DIFF
--- a/project/app/Http/Controllers/Admin/Products/ProductController.php
+++ b/project/app/Http/Controllers/Admin/Products/ProductController.php
@@ -328,7 +328,7 @@ class ProductController extends Controller
         $fields = $request->only(
             'productAttributeQuantity',
             'productAttributePrice',
-            'sale_price',
+            'salePrice',
             'default'
         );
 
@@ -341,8 +341,8 @@ class ProductController extends Controller
         $price = $fields['productAttributePrice'];
 
         $sale_price = null;
-        if (isset($fields['sale_price'])) {
-            $sale_price = $fields['sale_price'];
+        if (isset($fields['salePrice'])) {
+            $sale_price = $fields['salePrice'];
         }
 
         $attributeValues = $request->input('attributeValue');

--- a/project/app/Http/Controllers/Front/CartController.php
+++ b/project/app/Http/Controllers/Front/CartController.php
@@ -103,7 +103,8 @@ class CartController extends Controller
         if ($request->has('productAttribute')) {
 
             $attr = $this->productAttributeRepo->findProductAttributeById($request->input('productAttribute'));
-            $product->price = $attr->price;
+
+            $product->price = $attr->sale_price ?? $attr->price;
 
             $options['product_attribute_id'] = $request->input('productAttribute');
             $options['combination'] = $attr->attributesValues->toArray();

--- a/project/app/Shop/Orders/Repositories/OrderRepository.php
+++ b/project/app/Shop/Orders/Repositories/OrderRepository.php
@@ -18,6 +18,7 @@ use App\Shop\Couriers\Courier;
 use App\Shop\Orders\Order;
 use App\Shop\Orders\Repositories\Interfaces\OrderRepositoryInterface;
 use App\Shop\Orders\Transformers\OrderTransformable;
+use App\Shop\ProductAttributes\Repositories\ProductAttributeRepositoryInterface;
 use App\Shop\Products\Product;
 use App\Shop\Products\Repositories\ProductRepository;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
@@ -122,6 +123,11 @@ class OrderRepository extends BaseRepository implements OrderRepositoryInterface
      */
     public function associateProduct(Product $product, int $quantity = 1, array $data = [])
     {
+        if (isset($data['product_attribute_id'])) {
+            $attr = resolve(ProductAttributeRepositoryInterface::class)->findProductAttributeById($data['product_attribute_id']);
+            $product->price = $attr->sale_price ?? $attr->price;
+        }
+
         $this->model->products()->attach($product, [
             'quantity' => $quantity,
             'product_name' => $product->name,

--- a/project/database/migrations/2021_06_04_135827_alter_sale_price_type_in_product_attributes_table.php
+++ b/project/database/migrations/2021_06_04_135827_alter_sale_price_type_in_product_attributes_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AlterSalePriceTypeInProductAttributesTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        DB::statement('ALTER TABLE product_attributes CHANGE sale_price sale_price NUMERIC(8, 2) DEFAULT NULL');
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('product_attributes', function (Blueprint $table) {
+            $table->string('sale_price')->nullable()->change();
+        });
+    }
+}

--- a/project/database/migrations/2021_06_04_135827_alter_sale_price_type_in_product_attributes_table.php
+++ b/project/database/migrations/2021_06_04_135827_alter_sale_price_type_in_product_attributes_table.php
@@ -13,7 +13,7 @@ class AlterSalePriceTypeInProductAttributesTable extends Migration
      */
     public function up()
     {
-        DB::statement('ALTER TABLE product_attributes CHANGE sale_price sale_price NUMERIC(8, 2) DEFAULT NULL');
+        DB::raw('ALTER TABLE product_attributes MODIFY sale_price NUMERIC(8, 2) DEFAULT NULL');
     }
 
     /**

--- a/project/resources/views/layouts/front/product.blade.php
+++ b/project/resources/views/layouts/front/product.blade.php
@@ -55,7 +55,9 @@
                                             @foreach($productAttribute->attributesValues as $value)
                                                 {{ $value->attribute->name }} : {{ ucwords($value->value) }}
                                             @endforeach
-                                            @if(!is_null($productAttribute->price))
+                                            @if(!is_null($productAttribute->sale_price))
+                                                ( {{ config('cart.currency_symbol') }} {{ $productAttribute->sale_price }})
+                                            @elseif(!is_null($productAttribute->price))
                                                 ( {{ config('cart.currency_symbol') }} {{ $productAttribute->price }})
                                             @endif
                                         </option>


### PR DESCRIPTION
I don´t exactly know the intention of the sale price usage, but made a fix for the https://github.com/jsdecena/laracom/issues/228 anyways.

- The sale price now saves to the database, as a float number
- If the attribute marked as default price, the sale price shows on the product list
- The attribute dropdown shows the sale price (if any)
- Both the cart and the order use the sale price