### PR TITLE
Fix: can't update order status

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ See full [documentation](https://jsdecena.github.io/laracom)
 ### In your teminal, issue these commands
 
 - RUN `docker-compose up -d --build`
+- If your runtime is apple silicon, use `docker-compose -f docker-compose-m1.yml up -d --build` command
 - RUN `docker exec -it app bash`
 - Inside the container, run `composer install && chmod -R 777 storage/ bootstrap/cache/`
 - Inside the container, run `php artisan migrate --seed`

--- a/docker-compose-m1.yml
+++ b/docker-compose-m1.yml
@@ -1,0 +1,52 @@
+version: '3'
+services:
+  app:
+    build: .
+    container_name: app
+    restart: unless-stopped
+    tty: true
+    environment:
+      SERVICE_NAME: app-api
+      SERVICE_TAGS: dev
+    working_dir: /var/www
+    volumes:
+      - ./project:/var/www
+      - ./php/local.ini:/usr/local/etc/php/conf.d/local.ini
+    networks:
+      - app-network
+  webserver:
+    image: nginx:alpine
+    container_name: webserver
+    restart: unless-stopped
+    tty: true
+    ports:
+      - "8000:8000"
+    volumes:
+      - ./project:/var/www
+      - ./nginx/conf.d/:/etc/nginx/conf.d/
+    networks:
+      - app-network
+  db:
+    image: mysql:5.7
+    container_name: db
+    restart: unless-stopped
+    tty: true
+    platform: linux/amd64
+    ports:
+      - "3306:3306"
+    environment:
+      MYSQL_DATABASE: homestead
+      MYSQL_USER: homestead
+      MYSQL_ROOT_PASSWORD: secret
+      SERVICE_TAGS: dev
+      SERVICE_NAME: mysql
+    volumes:
+      - ./dbdata:/var/lib/mysql
+    networks:
+      - app-network
+networks:
+  app-network:
+    driver: bridge
+volumes:
+  dbdata:
+    driver: local

--- a/project/app/Shop/OrderStatuses/Requests/UpdateOrderStatusRequest.php
+++ b/project/app/Shop/OrderStatuses/Requests/UpdateOrderStatusRequest.php
@@ -3,7 +3,6 @@
 namespace App\Shop\OrderStatuses\Requests;
 
 use App\Shop\Base\BaseFormRequest;
-use Illuminate\Support\Facades\Log;
 use Illuminate\Validation\Rule;
 
 class UpdateOrderStatusRequest extends BaseFormRequest

--- a/project/app/Shop/OrderStatuses/Requests/UpdateOrderStatusRequest.php
+++ b/project/app/Shop/OrderStatuses/Requests/UpdateOrderStatusRequest.php
@@ -3,6 +3,7 @@
 namespace App\Shop\OrderStatuses\Requests;
 
 use App\Shop\Base\BaseFormRequest;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Validation\Rule;
 
 class UpdateOrderStatusRequest extends BaseFormRequest
@@ -15,7 +16,7 @@ class UpdateOrderStatusRequest extends BaseFormRequest
     public function rules()
     {
         return [
-            'name' => ['required', Rule::unique('order_statuses')->ignore($this->segment('4'))]
+            'name' => ['required', Rule::unique('order_statuses')->ignore($this->order_status)]
         ];
     }
 }


### PR DESCRIPTION
On the Edit Order Status screen, an error occurred when pressing the Update button without changing any values.
The cause was the uniqueness of UpdateOrderStatusRequest. The uniqueness check should have been performed on records other than the ID of the update target, but the uniqueness check was performed on the update target itself.
After the fix, I am running OrderStatusUnitTest.php.
The test on the screen is fine.
