### PR TITLE
Addition to README about .env files

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,35 +8,39 @@
 [![FOSSA Status](https://app.fossa.io/api/projects/git%2Bgithub.com%2FLaracommerce%2Flaracom.svg?type=shield)](https://app.fossa.io/projects/git%2Bgithub.com%2FLaracommerce%2Flaracom?ref=badge_shield)
 
 # Get discount on Digital Ocean
+
 Sign-up with [Digital Ocean and get $10 discount](https://m.do.co/c/bce94237de96)!
 
 # Laravel FREE E-Commerce Software
 
 Features Provided
-- Products
-- Cart
-- Checkout
-- Categories
-- Customers
-- Orders
-- Payment
-- Couriers
-- Employees
 
-- To view more details of the features 
-See full [documentation](https://jsdecena.github.io/laracom)
+-   Products
+-   Cart
+-   Checkout
+-   Categories
+-   Customers
+-   Orders
+-   Payment
+-   Couriers
+-   Employees
+
+-   To view more details of the features
+    See full [documentation](https://jsdecena.github.io/laracom)
 
 # Simplified DOCKER setup
+
 ### In your teminal, issue these commands
 
-- RUN `docker-compose up -d --build`
-- If your runtime is apple silicon, use `docker-compose -f docker-compose-m1.yml up -d --build` command
-- RUN `docker exec -it app bash`
-- Inside the container, run `composer install && chmod -R 777 storage/ bootstrap/cache/`
-- Inside the container, run `php artisan migrate --seed`
-- While inside the container, compile the assets with `npm i && npm run dev`
-- While inside the container, link the images `php artisan storage:link`
-- OPEN [http://localhost:8000](http://localhost:8000)
+-   RUN `docker-compose up -d --build`
+-   If your runtime is apple silicon, use `docker-compose -f docker-compose-m1.yml up -d --build` command
+-   You will need to replace the **.env.example** file with a **.env** file on your host machine.
+-   RUN `docker exec -it app bash`
+-   Inside the container, run `composer install && chmod -R 777 storage/ bootstrap/cache/`
+-   Inside the container, run `php artisan migrate --seed`
+-   While inside the container, compile the assets with `npm i && npm run dev`
+-   While inside the container, link the images `php artisan storage:link`
+-   OPEN [http://localhost:8000](http://localhost:8000)
 
 # Author
 
@@ -46,6 +50,6 @@ See full [documentation](https://jsdecena.github.io/laracom)
 
 <a href="https://github.com/jsdecena/laracom/graphs/contributors"><img src="https://opencollective.com/laracom/contributors.svg?width=890" title="contributors" alt="contributors" /></a>
 
-
 ## License
+
 [![FOSSA Status](https://app.fossa.io/api/projects/git%2Bgithub.com%2FLaracommerce%2Flaracom.svg?type=large)](https://app.fossa.io/projects/git%2Bgithub.com%2FLaracommerce%2Flaracom?ref=badge_large)


### PR DESCRIPTION
# About .emv file

On the Dockerfile, 
`project/.env.example . /.env`
 is executed.

However, in docker-compose.yml . /project:/var/www is fileshared, .env is not generated and the original .env.example and .env.test are reflected in the container.

Therefore, developers need to rename .env.example to .env before launching the container or else 
`php artisan migrate --seed`
will result in an error.

This has been added to the README.

# P.S

Is it possible to add me to the Contirubutors in the README?

![image](https://user-images.githubusercontent.com/44870505/215471199-d0d8917a-0c29-4cfc-bbf1-b3ae7fa4a3ff.png)
