### PR TITLE
#Fix Cover image is not displayed on the top page

### DIFF
--- a/project/app/Http/Controllers/Front/HomeController.php
+++ b/project/app/Http/Controllers/Front/HomeController.php
@@ -33,6 +33,7 @@ class HomeController
         $cat1->products = $cat1->products->map(function (Product $item) {
             return $this->transformProduct($item);
         });
+
         $cat2 = $this->categoryRepo->findCategoryById(3);
         $cat2->products = $cat2->products->map(function (Product $item) {
             return $this->transformProduct($item);

--- a/project/app/Http/Controllers/Front/HomeController.php
+++ b/project/app/Http/Controllers/Front/HomeController.php
@@ -3,9 +3,13 @@
 namespace App\Http\Controllers\Front;
 
 use App\Shop\Categories\Repositories\Interfaces\CategoryRepositoryInterface;
+use App\Shop\Products\Product;
+use App\Shop\Products\Transformations\ProductTransformable;
 
 class HomeController
 {
+    use ProductTransformable;
+
     /**
      * @var CategoryRepositoryInterface
      */
@@ -26,7 +30,13 @@ class HomeController
     public function index()
     {
         $cat1 = $this->categoryRepo->findCategoryById(2);
+        $cat1->products = $cat1->products->map(function (Product $item) {
+            return $this->transformProduct($item);
+        });
         $cat2 = $this->categoryRepo->findCategoryById(3);
+        $cat2->products = $cat2->products->map(function (Product $item) {
+            return $this->transformProduct($item);
+        });
 
         return view('front.index', compact('cat1', 'cat2'));
     }


### PR DESCRIPTION
# Occurring event

Register a Cover image in the admin panel.

![image](https://user-images.githubusercontent.com/44870505/215624510-42b49e09-6059-4f9e-b7df-b1eac4925923.png)

Check on the top page

![image](https://user-images.githubusercontent.com/44870505/215624586-a41309f1-2aaa-4d3e-9f0f-395b4a9efe78.png)

Cover image is not displayed.

# Direct cause

The path of the Cover image on the top page is not correct.

## Wrong(before fix)

![image](https://user-images.githubusercontent.com/44870505/215624784-f6612011-6b45-4bab-b21f-e6fc882d9127.png)

## Correct(before fix)

Temporary rewrite of path from "validation" showed up correctly

![image](https://user-images.githubusercontent.com/44870505/215624840-b30e7fcf-d854-43c5-bea4-21966eb3ea96.png)

# Root cause

Not using function transformProduct of trait ProductTransformable.

For example, the Cover image on the admin page is displayed correctly because using function transformProduct.

![image](https://user-images.githubusercontent.com/44870505/215625463-0c27ca40-2899-47e6-8493-b452b8ab802a.png)

# Corrective actions

Set the products acquired in HomeController to the correct paths by using the function transformProduct of therait ProductTransformable, and set them to the variables cat1 and cat2.

This caused the image to appear correctly on the Top page.

![image](https://user-images.githubusercontent.com/44870505/215626160-045c0909-4a5b-4369-8ea8-9402469f5645.png)

